### PR TITLE
chore: update actions/cache to v4

### DIFF
--- a/lib/oz/.github/workflows/docs.yml
+++ b/lib/oz/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: '**/node_modules'
@@ -22,4 +22,4 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       - run: bash scripts/git-user-config.sh
       - run: node scripts/update-docs-branch.js
-      - run: git push --all origin 
+      - run: git push --all origin

--- a/lib/oz/.github/workflows/test.yml
+++ b/lib/oz/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: '**/node_modules'
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: '**/node_modules'
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: '**/node_modules'


### PR DESCRIPTION
The v2 version of the actions is getting deprecated soon.